### PR TITLE
ftell return type can be bigger than a D int

### DIFF
--- a/src/imgui/gl3_renderer.d
+++ b/src/imgui/gl3_renderer.d
@@ -347,7 +347,7 @@ bool imguiRenderGLInit(const(char)[] fontpath)
     if (!fp)
         return false;
     fseek(fp, 0, SEEK_END);
-    int size = ftell(fp);
+    long size = ftell(fp);
     fseek(fp, 0, SEEK_SET);
 
     ubyte* ttfBuffer = cast(ubyte*)malloc(size);


### PR DESCRIPTION
I guess it could be auto instead, but meh, long is always enough...
