### PR TITLE
Never use negative-sized scissor.

### DIFF
--- a/src/imgui/api.d
+++ b/src/imgui/api.d
@@ -429,7 +429,12 @@ bool imguiBeginScrollArea(const(char)[] title, int xPos, int yPos, int width, in
 
     addGfxCmdText(xPos + AREA_HEADER / 2, yPos + height - AREA_HEADER / 2 - TEXT_HEIGHT / 2, TextAlign.left, title, colorScheme.scroll.area.text);
 
-    addGfxCmdScissor(xPos + SCROLL_AREA_PADDING, yPos + SCROLL_AREA_PADDING, width - SCROLL_AREA_PADDING * 4, height - AREA_HEADER - SCROLL_AREA_PADDING);
+    // The max() ensures we never have zero- or negative-sized scissor rectangle when the window is very small,
+    // avoiding a segfault.
+    addGfxCmdScissor(xPos + SCROLL_AREA_PADDING, 
+                     yPos + SCROLL_AREA_PADDING,
+                     max(1, width - SCROLL_AREA_PADDING * 4), 
+                     max(1, height - AREA_HEADER - SCROLL_AREA_PADDING));
 
     return g_insideScrollArea;
 }


### PR DESCRIPTION
As the size of a scissor rectangle used in ScrollArea is defined as (width - something, height - something),
the rectangle would have negative size if e.g. the scissor area size is proportional to window size and the
window gets resized to a small size. This would result in a segfault (at least on AMD Catalyst/Linux).

E.g. when a user plays around with window width/height the program (even dimgui examples) would crash.

I worked around this by forcing the scissor area to be at least 1x1 pixels large.
