### PR TITLE
constness fix for D 2.066

### DIFF
--- a/src/imgui/engine.d
+++ b/src/imgui/engine.d
@@ -304,7 +304,7 @@ void updateInput(int mx, int my, ubyte mbut, int scroll)
     g_state.scroll = scroll;
 }
 
-const imguiGfxCmd* imguiGetRenderQueue()
+const(imguiGfxCmd*) imguiGetRenderQueue()
 {
     return g_gfxCmdQueue.ptr;
 }


### PR DESCRIPTION
Since D 2.066, the C/C++ const style for function return type is now disallowed.
