### PR TITLE
Text input support (and some fixes).

### DIFF
--- a/examples/demo/dub.json
+++ b/examples/demo/dub.json
@@ -24,6 +24,11 @@
 
     "mainSourceFile": "demo.d",
 
+    "libs-posix": [
+        "dl",
+        "glfw",
+    ],
+
     "dependencies": {
         "dimgui": {"path": "../../", "version": "~master"},
         "glfw-drey": ">=0.0.2",

--- a/src/imgui/gl3_renderer.d
+++ b/src/imgui/gl3_renderer.d
@@ -30,7 +30,7 @@ import imgui.api;
 import imgui.engine;
 import imgui.stdb_truetype;
 
-package:
+private:
 // Draw up to 65536 unicode glyphs.  What this will actually do is draw *only glyphs the
 // font supports* until it will run out of glyphs or texture space (determined by
 // g_font_texture_size).  The actual number of glyphs will be in thousands (ASCII is
@@ -85,6 +85,13 @@ __gshared GLuint g_programTextureLocation  = 0;
 enum TEMP_COORD_COUNT = 100;
 enum int CIRCLE_VERTS = 8 * 4;
 immutable float[4] g_tabStops = [150, 210, 270, 330];
+
+package:
+
+uint maxCharacterCount() @trusted nothrow @nogc
+{
+    return g_max_character_count;
+}
 
 void imguifree(void* ptr, void* /*userptr*/)
 {

--- a/src/imgui/gl3_renderer.d
+++ b/src/imgui/gl3_renderer.d
@@ -585,6 +585,11 @@ float getTextLength(stbtt_bakedchar* chardata, const(char)[] text)
     return len;
 }
 
+float getTextLength(const(char)[] text)
+{
+    return getTextLength(g_cdata.ptr, text);
+}
+
 void drawText(float x, float y, const(char)[] text, int align_, uint col)
 {
     if (!g_ftex)


### PR DESCRIPTION
I started writing this a while ago but abandoned it for a few months. An unfortunate result is that
the commits are rather big/coarse and there are some interspersed fixes I made along the way.

The code is based on an abandoned imgui pull request: https://github.com/AdrienHerubel/imgui/pull/2/files
though there were various changes.

Changes:

* A text input widget. Takes a label, a buffer to store input, a reference to a slice of entered buffer in that buffer. There's also an optional parameter to force the widget to be immediately 'inputable' (somewhat out of place, but I found I needed it most of the time)
* Docs for the new stuff
* Optional 'unicode input' parameter for `imguiBeginFrame()` (needed for text input - user can get it from GLFW/SDL/others)
* Fixed demo sample build on Linux.
* Example usage of text input in the demo sample.
* Made renderer globals private (mainly to ensure I wasn't causing any unneeded dependencies).