### PR TITLE
Scope parameters to edge compare

### DIFF
--- a/src/imgui/stdb_truetype.d
+++ b/src/imgui/stdb_truetype.d
@@ -1459,7 +1459,7 @@ void stbtt__rasterize_sorted_edges(stbtt__bitmap* result, stbtt__edge* e, int n,
         STBTT_free(scanline, userdata);
 }
 
-extern(C) int stbtt__edge_compare(const void* p, const void* q)
+extern(C) int stbtt__edge_compare(scope const void* p, scope const void* q)
 {
     stbtt__edge* a = cast(stbtt__edge*)p;
     stbtt__edge* b = cast(stbtt__edge*)q;


### PR DESCRIPTION
The comparison function passed to core.stdc.stdlib.qsort, stbtt__edge_compare, requires the parameters have the scope attribute. This change was introduced to the D Runtime on Feb 13, 2017. The project will not compile otherwise.