### PR TITLE
Fix examples/*/dub.json to work on macOS

### DIFF
--- a/examples/colors/dub.json
+++ b/examples/colors/dub.json
@@ -28,7 +28,10 @@
 
     "libs-posix": [
         "dl",
-        "glfw3",
+        "glfw3"
+    ],
+
+    "libs-linux": [
         "GL",
         "Xrandr",
         "Xext",

--- a/examples/demo/dub.json
+++ b/examples/demo/dub.json
@@ -28,7 +28,10 @@
 
     "libs-posix": [
         "dl",
-        "glfw3",
+        "glfw3"
+    ],
+
+    "libs-linux": [
         "GL",
         "Xrandr",
         "Xext",

--- a/examples/memory/dub.json
+++ b/examples/memory/dub.json
@@ -30,7 +30,10 @@
 
     "libs-posix": [
         "dl",
-        "glfw3",
+        "glfw3"
+    ],
+
+    "libs-linux": [
         "GL",
         "Xrandr",
         "Xext",


### PR DESCRIPTION
Move libs not present or needed on macOS from libs-posix to libs-linux. The libs-linux section may need to be duplicated to support other posix platforms.

Note that even after this commit examples/memory does not run on macOS as macOS supports neither GL_ARB_debug_output nor GL_KHR_debug.