### PR TITLE
Fix examples to properly scale mouse input on macOS with retina displays

### DIFF
--- a/examples/colors/colors.d
+++ b/examples/colors/colors.d
@@ -28,6 +28,11 @@ import imgui;
 
 import window;
 
+version (OSX)
+    version = MaybeHighResolutionDisplay;
+version (iOS)
+    version = MaybeHighResolutionDisplay;
+
 struct RGBAF
 {
     float r = 0.0, g = 0.0, b = 0.0, a = 0.0;
@@ -110,6 +115,25 @@ struct GUI
         double mouseX;
         double mouseY;
         glfwGetCursorPos(window.window, &mouseX, &mouseY);
+
+        version (MaybeHighResolutionDisplay)
+        {
+            // Scale the cursor position for high-resolution displays.
+            if (mouseXToWindowFactor == 0) // need to initialize
+            {
+                int virtualWindowWidth, virtualWindowHeight;
+                glfwGetWindowSize(window.window, &virtualWindowWidth, &virtualWindowHeight);
+                if (virtualWindowWidth != 0 && virtualWindowHeight != 0)
+                {
+                    int frameBufferWidth, frameBufferHeight;
+                    glfwGetFramebufferSize(window.window, &frameBufferWidth, &frameBufferHeight);
+                    mouseXToWindowFactor = double(frameBufferWidth) / virtualWindowWidth;
+                    mouseYToWindowFactor = double(frameBufferHeight) / virtualWindowHeight;
+                }
+            }
+            mouseX *= mouseXToWindowFactor;
+            mouseY *= mouseYToWindowFactor;
+        }
 
         const scrollAreaWidth = windowWidth / 4;
         const scrollAreaHeight = windowHeight - 20;
@@ -223,6 +247,11 @@ struct GUI
 
         windowWidth = width;
         windowHeight = height;
+        version (MaybeHighResolutionDisplay)
+        {
+            mouseXToWindowFactor = 0;
+            mouseYToWindowFactor = 0;
+        }
     }
 
     void onScroll(double hOffset, double vOffset)
@@ -234,6 +263,11 @@ private:
     Window window;
     int windowWidth;
     int windowHeight;
+version (MaybeHighResolutionDisplay)
+{
+    double mouseXToWindowFactor = 0;
+    double mouseYToWindowFactor = 0;
+}
 
     bool checkState1 = false;
     bool checkState2 = false;

--- a/examples/demo/demo.d
+++ b/examples/demo/demo.d
@@ -21,6 +21,11 @@ import imgui;
 
 import window;
 
+version (OSX)
+    version = MaybeHighResolutionDisplay;
+version (iOS)
+    version = MaybeHighResolutionDisplay;
+
 struct GUI
 {
     this(Window window)
@@ -54,6 +59,25 @@ struct GUI
         double mouseX;
         double mouseY;
         glfwGetCursorPos(window.window, &mouseX, &mouseY);
+
+        version (MaybeHighResolutionDisplay)
+        {
+            // Scale the cursor position for high-resolution displays.
+            if (mouseXToWindowFactor == 0) // need to initialize
+            {
+                int virtualWindowWidth, virtualWindowHeight;
+                glfwGetWindowSize(window.window, &virtualWindowWidth, &virtualWindowHeight);
+                if (virtualWindowWidth != 0 && virtualWindowHeight != 0)
+                {
+                    int frameBufferWidth, frameBufferHeight;
+                    glfwGetFramebufferSize(window.window, &frameBufferWidth, &frameBufferHeight);
+                    mouseXToWindowFactor = double(frameBufferWidth) / virtualWindowWidth;
+                    mouseYToWindowFactor = double(frameBufferHeight) / virtualWindowHeight;
+                }
+            }
+            mouseX *= mouseXToWindowFactor;
+            mouseY *= mouseYToWindowFactor;
+        }
 
         const scrollAreaWidth = windowWidth / 4;
         const scrollAreaHeight = windowHeight - 20;
@@ -196,6 +220,11 @@ struct GUI
 
         windowWidth = width;
         windowHeight = height;
+        version (MaybeHighResolutionDisplay)
+        {
+            mouseXToWindowFactor = 0;
+            mouseYToWindowFactor = 0;
+        }
     }
 
     void onScroll(double hOffset, double vOffset)
@@ -219,7 +248,11 @@ private:
     Window window;
     int windowWidth;
     int windowHeight;
-
+version (MaybeHighResolutionDisplay)
+{
+    double mouseXToWindowFactor = 0;
+    double mouseYToWindowFactor = 0;
+}
     bool checkState1 = false;
     bool checkState2 = false;
     bool checkState3 = true;

--- a/examples/memory/memory.d
+++ b/examples/memory/memory.d
@@ -26,6 +26,11 @@ import imgui;
 
 import window;
 
+version (OSX)
+    version = MaybeHighResolutionDisplay;
+version (iOS)
+    version = MaybeHighResolutionDisplay;
+
 struct GUI
 {
     this(Window window)
@@ -53,6 +58,25 @@ struct GUI
         double mouseX;
         double mouseY;
         glfwGetCursorPos(window.window, &mouseX, &mouseY);
+
+        version (MaybeHighResolutionDisplay)
+        {
+            // Scale the cursor position for high-resolution displays.
+            if (mouseXToWindowFactor == 0) // need to initialize
+            {
+                int virtualWindowWidth, virtualWindowHeight;
+                glfwGetWindowSize(window.window, &virtualWindowWidth, &virtualWindowHeight);
+                if (virtualWindowWidth != 0 && virtualWindowHeight != 0)
+                {
+                    int frameBufferWidth, frameBufferHeight;
+                    glfwGetFramebufferSize(window.window, &frameBufferWidth, &frameBufferHeight);
+                    mouseXToWindowFactor = double(frameBufferWidth) / virtualWindowWidth;
+                    mouseYToWindowFactor = double(frameBufferHeight) / virtualWindowHeight;
+                }
+            }
+            mouseX *= mouseXToWindowFactor;
+            mouseY *= mouseYToWindowFactor;
+        }
 
         const scrollAreaWidth = (windowWidth / 4) - 10;  // -10 to allow room for the scrollbar
         const scrollAreaHeight = windowHeight - 20;
@@ -199,6 +223,11 @@ struct GUI
 
         windowWidth = width;
         windowHeight = height;
+        version (MaybeHighResolutionDisplay)
+        {
+            mouseXToWindowFactor = 0;
+            mouseYToWindowFactor = 0;
+        }
     }
 
     void onScroll(double hOffset, double vOffset)
@@ -210,6 +239,11 @@ private:
     Window window;
     int windowWidth;
     int windowHeight;
+version (MaybeHighResolutionDisplay)
+{
+    double mouseXToWindowFactor = 0;
+    double mouseYToWindowFactor = 0;
+}
 
     int scrollArea1 = 0;
     int scrollArea2 = 0;


### PR DESCRIPTION
The cursor position scaling code is enabled by setting `version = MaybeHighResolutionDisplay`. This is set for OSX and iOS and can be selectively enabled for additional platforms as needed.